### PR TITLE
Added grouping functionality and modified the web pages to use it.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,6 +1,6 @@
 # API Guide
 
-RCFC uses a Rest API to provide buttons to whatever the UI is. 
+RCFC uses a Rest API to provide buttons to whatever the UI is.
 
 
 ## Endpoints
@@ -11,9 +11,9 @@ This will return the following JSON information
 ```
 {
     "buttons": [
-                <button-1>, 
-                <button-2>, 
-                ... 
+                <button-1>,
+                <button-2>,
+                ...
                 <button-n>
                ]
 }
@@ -24,32 +24,51 @@ Every button will have the following:
 
 * ID: a string used for uniquely identifying buttons
 * Type: A string stating the type (described below)
+* Group: A string stating the group that the button belongs to (can be None)
 * Button-specific fields
+
+### /groups
+
+This will return the following JSON information
+```
+{
+  "groups": [
+             <group-1>,
+             <group-2>,
+             ...
+             <button-n>
+            ]
+}
+```
+
+This will be a unique set of Group references (String) that are currently referenced from buttons.
 
 #### Simple Buttons
 A button that you can press, containing some text
 
-Data: 
+Data:
 ```
 {
   "id": <id>,
   "type": "button.simple",
+  "group": "Label for the Group"
   "text": <text of button>
 }
 ```
 
 The text is the text displayed on the actual button.
- 
+
 To interact with this button, send a POST request to `/buttons/<id>`
 
 #### Toggle Buttons
 A button that can be flipped on/off.
 
-Data: 
+Data:
 ```
 {
     "id": <id>,
     "type": "button.toggle",
+    "group": "Label for the Group"
     "state": True/False
     "text": "Label for the Data"
 }

--- a/rcfc/button.py
+++ b/rcfc/button.py
@@ -5,16 +5,19 @@ A collection of buttons to be displayed in the GUI
 from rcfc.server import register_post, register_post_with_state
 
 
-def simple(text):
+def simple(text, group=None):
     """ A simple press-button decorator that takes a title """
     def wrapper(func):
-        register_post({"text": text,  "type": "button.simple"}, func)
+        register_post({"text": text,
+                       "type": "button.simple",
+                       "group": group},
+                      func)
     return wrapper
 
 
-def toggle(text, getter):
+def toggle(text, getter, group=None):
     """ A on/off slider toggle """
     def wrapper(setter):
-        button = {"text": text, "type": "button.toggle"}
+        button = {"text": text, "type": "button.toggle", "group": group}
         register_post_with_state(button, getter, setter)
     return wrapper

--- a/rcfc/demo.py
+++ b/rcfc/demo.py
@@ -21,12 +21,25 @@ def simple_button2():
     print("You pressed a different button!")
 
 
+@button.simple("Group Button!", group="Group A")
+def simple_group_button():
+    """
+    Print to console that a button was pressed
+    """
+    print("You pressed a group button!")
+
+
 bool_value = False
+group_a_bool_value = False
 
 
 def getter():
     """ Return our boolean value"""
     return bool_value
+
+
+def getter_a():
+    return group_a_bool_value
 
 
 @button.toggle("Toggle!", getter)
@@ -35,6 +48,14 @@ def toggle_button(toggle):
     print(f"The toggle was set to {toggle}")
     global bool_value
     bool_value = toggle
+
+
+@button.toggle("Toggle!", getter_a, group="Group A")
+def toggle_group_button(toggle):
+    """ Toggle on or off """
+    print(f"The group toggle was set to {toggle}")
+    global group_a_bool_value
+    group_a_bool_value = toggle
 
 
 def main():

--- a/rcfc/server.py
+++ b/rcfc/server.py
@@ -101,6 +101,16 @@ def get_buttons_registered():
     return {"buttons": buttons_with_state}
 
 
+@get("/groups")
+def get_groups_registered():
+    """
+    Get groups registered
+    :return: a dictionary containing the groups registered
+    """
+    button_groups = list(set([dict(b)["group"] for b in _buttons_registered]))
+    return {"groups": button_groups}
+
+
 @get("/")
 def route_index():
     """ Route to the index page """

--- a/rcfc/static/index.html
+++ b/rcfc/static/index.html
@@ -6,17 +6,23 @@
     <script src="static/index.js" type="text/javascript"></script>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" />
     <link rel="stylesheet" href="static/static.css" />
+    <link rel="stylesheet" href="https://www.w3schools.com/w3css/4/w3.css">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
 <body>
+    <div id="group-tabs" class="w3-bar w3-black">
+    </div>
     <div id="groups">
-        <button class="groupbtn">Groups</button>
-        <div id="group-content"></div>
     </div>
-    <div id="top">
-        <div class="container col-xs-offset-3 col-xs-6 text-center" id="remote">
-            <div class="row" ></div>
-        </div>
-    </div>
+  <script>
+    function openGroup(groupId) {
+      var i;
+      var x = document.getElementsByClassName("group");
+      for (i = 0; i < x.length; i++) {
+        x[i].style.display = "none";
+      }
+      document.getElementById(groupId).style.display = "block";
+    }
+  </script>
 </body>
 </html>

--- a/rcfc/static/index.html
+++ b/rcfc/static/index.html
@@ -9,8 +9,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
 <body>
-    <div id="top"><div class="container col-xs-offset-3 col-xs-6 text-center" id="remote">
-        <div class="row" ></div>
-    </div></div>
+    <div id="groups">
+        <button class="groupbtn">Groups</button>
+        <div id="group-content"></div>
+    </div>
+    <div id="top">
+        <div class="container col-xs-offset-3 col-xs-6 text-center" id="remote">
+            <div class="row" ></div>
+        </div>
+    </div>
 </body>
 </html>

--- a/rcfc/static/index.js
+++ b/rcfc/static/index.js
@@ -30,16 +30,11 @@
     }
 
     function displayGroup(group) {
-      if(group == null) {
-        name = "unassigned"
-      } else {
-        name = group
-      }
-      let id = name.replace(/ /g, '_');
-      $("#group-content").append("<button id='" + id + "'>" + name + "</button>");
-      $("#" + id).click(function () {
+      name = group || "unassigned";
+      $("#group-content").append("<button id='" + name + "'>" + name + "</button>");
+      $("#" + name.replace(/([ /])/g, '\\$1')).click(function () {
         clearButtons();
-        console.log(group);
+        console.log("Getting group info");
         loadButtons(group);
       });
     }

--- a/rcfc/static/index.js
+++ b/rcfc/static/index.js
@@ -11,15 +11,16 @@
         return "button" + id;
     }
 
-    function displayButton(button) {
+    function displayButton(parentGroupId, button) {
+      console.log('loading ' + button.text)
         if (button.type === "button.simple") {
-            $("#remote").append("<div class='row'><button class='btn-lg btn-info' id='" + getId(button.id) + "'>" + button.text + "</button></div>");
+            $("#" + parentGroupId).append("<div class='row'><button class='btn-lg btn-info' id='" + getId(button.id) + "'>" + button.text + "</button></div>");
             $("#" + getId(button.id)).click(function () {
                 $.post({url: "/buttons/" + button.id});
             });
         }
         if (button.type === "button.toggle") {
-            $("#remote").append("<div class='row'>" + button.text + ": <label class='switch'><input type='checkbox' id='" + getId(button.id) + "'><span class='slider round'></span></label></button></div>");
+            $("#" + parentGroupId).append("<div class='row'>" + button.text + ": <label class='switch'><input type='checkbox' id='" + getId(button.id) + "'><span class='slider round'></span></label></button></div>");
             $("#" + getId(button.id)).click(function () {
                 $.post({url: "/buttons/" + button.id, data: JSON.stringify({value: $("#" + getId(button.id)).prop('checked')}), contentType: "application/json"})
             });
@@ -30,40 +31,35 @@
     }
 
     function displayGroup(group) {
-      name = group || "unassigned";
-      $("#group-content").append("<button id='" + name + "'>" + name + "</button>");
-      $("#" + name.replace(/([ /])/g, '\\$1')).click(function () {
-        clearButtons();
-        console.log("Getting group info");
-        loadButtons(group);
-      });
-    }
+      name = group || "Unassigned";
+      var uniqueID = new Date().getTime();
+      $("#group-tabs").append('<button class=\"w3-bar-item w3-button\" onclick=\"openGroup(\'' + uniqueID + '\')\">' + name + '</button>');
 
-    function clearButtons() {
-      $("#remote").empty();
+      $("#groups").append('<div id="' + uniqueID + '" class="container col-xs-offset-3 col-xs-6 text-center group"></div>')
+      console.log('loading group ' + name);
+      loadButtons(group, uniqueID)
     }
 
     function displayGroups(data) {
       data.groups.forEach(displayGroup);
     }
 
-    function displayButtons(data) {
-        data.buttons.forEach(displayButton);
+    function displayButtons(groupId, data) {
+        data.buttons.forEach(function (button) { displayButton(groupId, button); });
     }
 
-    function displayButtonsInGroup(data, group) {
+    function displayButtonsInGroup(data, group, groupId) {
       data.buttons = data.buttons.filter(button => {
         return button.group == group
       });
-      displayButtons(data);
+      displayButtons(groupId, data);
     }
 
-    function loadButtons(group) {
+    function loadButtons(group, groupId) {
         $.ajax({
             url: "/buttons",
             success: function(data) {
-              console.log(data)
-              displayButtonsInGroup(data, group)
+              displayButtonsInGroup(data, group, groupId)
             },
             dataType: "json"
         });

--- a/rcfc/static/index.js
+++ b/rcfc/static/index.js
@@ -29,17 +29,58 @@
         }
     }
 
+    function displayGroup(group) {
+      if(group == null) {
+        name = "unassigned"
+      } else {
+        name = group
+      }
+      let id = name.replace(/ /g, '_');
+      $("#group-content").append("<button id='" + id + "'>" + name + "</button>");
+      $("#" + id).click(function () {
+        clearButtons();
+        console.log(group);
+        loadButtons(group);
+      });
+    }
+
+    function clearButtons() {
+      $("#remote").empty();
+    }
+
+    function displayGroups(data) {
+      data.groups.forEach(displayGroup);
+    }
+
     function displayButtons(data) {
         data.buttons.forEach(displayButton);
     }
 
-    function loadButtons() {
+    function displayButtonsInGroup(data, group) {
+      data.buttons = data.buttons.filter(button => {
+        return button.group == group
+      });
+      displayButtons(data);
+    }
+
+    function loadButtons(group) {
         $.ajax({
             url: "/buttons",
-            success: displayButtons,
+            success: function(data) {
+              console.log(data)
+              displayButtonsInGroup(data, group)
+            },
             dataType: "json"
         });
     }
 
-    $(document).ready(loadButtons);
+    function loadGroups() {
+      $.ajax({
+        url: "/groups",
+        success: displayGroups,
+        dataType: "json"
+      });
+    }
+
+    $(document).ready(loadGroups);
 }());

--- a/rcfc/static/static.css
+++ b/rcfc/static/static.css
@@ -3,7 +3,7 @@
     background-color: lightgray;
 }
 
-button {
+.row .button {
     margin-top: 20px;
     margin-bottom: 20px;
 }
@@ -15,10 +15,10 @@ button {
     width: 60px;
     height: 34px;
   }
-  
+
   /* Hide default HTML checkbox */
   .switch input {display:none;}
-  
+
   /* The slider */
   .slider {
     position: absolute;
@@ -31,7 +31,7 @@ button {
     -webkit-transition: .4s;
     transition: .4s;
   }
-  
+
   .slider:before {
     position: absolute;
     content: "";
@@ -43,26 +43,75 @@ button {
     -webkit-transition: .4s;
     transition: .4s;
   }
-  
+
   input:checked + .slider {
     background-color: #2196F3;
   }
-  
+
   input:focus + .slider {
     box-shadow: 0 0 1px #2196F3;
   }
-  
+
   input:checked + .slider:before {
     -webkit-transform: translateX(26px);
     -ms-transform: translateX(26px);
     transform: translateX(26px);
   }
-  
+
   /* Rounded sliders */
   .slider.round {
     border-radius: 34px;
   }
-  
+
   .slider.round:before {
     border-radius: 50%;
-  } 
+  }
+
+/* Style The Dropdown Button */
+.groupbtn {
+    background-color: #4CAF50;
+    color: white;
+    padding: 16px;
+    font-size: 16px;
+    border: none;
+    cursor: pointer;
+}
+
+/* The container <div> - needed to position the dropdown content */
+.groups {
+    position: relative;
+    display: inline-block;
+}
+
+/* Dropdown Content (Hidden by Default) */
+.group-content {
+    display: none;
+    position: absolute;
+    background-color: #f9f9f9;
+    min-width: 160px;
+    box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
+    z-index: 1;
+}
+
+/* Links inside the dropdown */
+.group-content button {
+    color: black;
+    padding: 12px 16px;
+    text-decoration: none;
+    display: block;
+}
+
+/* Change color of dropdown links on hover */
+.group-content button:hover {
+  background-color: #f1f1f1;
+}
+
+/* Show the dropdown menu on hover */
+.groups:hover .group-content {
+    display: block;
+}
+
+/* Change the background color of the dropdown button when the dropdown content is shown */
+.groups:hover .groupbtn {
+    background-color: #3e8e41;
+}

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -51,16 +51,7 @@ def test_simple_button_registration_fails_when_arguments(mock_route):
 def test_group_simple_button_registration(mock_route):
     server.clear_buttons()
     button.simple("Group Button", "Group A")(do_nothing)
-    expected = {"text": "Group Button",
-                "type": "button.simple",
-                "group": "Group A",
-                "state": None,
-                "id": 0}
-    assert server.get_buttons_registered() == {"buttons": [expected]}
-
-    mock_route.assert_called_once_with("/buttons/0",
-                                       ["POST", "OPTIONS"],
-                                       IgnoredArgument())
+    assert server.get_buttons_registered()["buttons"][0]["group"] == "Group A"
 
 
 def mock_call(uri, headers, func):
@@ -104,20 +95,4 @@ def test_toggle_button_registration_with_invalid_args(mock_route):
 def test_toggle_button_registration(mock_route):
     server.clear_buttons()
     button.toggle("Toggle Button", do_nothing, "Group A")(set_bool)
-    expected = {"text": "Toggle Button",
-                "type": "button.toggle",
-                "group": "Group A",
-                "state": False,
-                "id": 0}
-
-    mock_route.side_effect = mock_call
-    assert server.get_buttons_registered() == {"buttons": [expected]}
-
-    global bool_value
-    bool_value = True
-    expected["state"] = True
-    assert server.get_buttons_registered() == {"buttons": [expected]}
-
-    mock_route.assert_called_once_with("/buttons/0",
-                                       ["POST", "OPTIONS"],
-                                       IgnoredArgument())
+    assert server.get_buttons_registered()["buttons"][0]["group"] == "Group A"

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -28,6 +28,7 @@ def test_simple_button_registration(mock_route):
     button.simple("this is a button")(do_nothing)
     expected = {"text": "this is a button",
                 "type": "button.simple",
+                "group": None,
                 "state": None,
                 "id": 0}
     assert server.get_buttons_registered() == {"buttons": [expected]}
@@ -46,6 +47,22 @@ def test_simple_button_registration_fails_when_arguments(mock_route):
     mock_route.assert_not_called()
 
 
+@patch("bottle.Bottle.route")
+def test_group_simple_button_registration(mock_route):
+    server.clear_buttons()
+    button.simple("Group Button", "Group A")(do_nothing)
+    expected = {"text": "Group Button",
+                "type": "button.simple",
+                "group": "Group A",
+                "state": None,
+                "id": 0}
+    assert server.get_buttons_registered() == {"buttons": [expected]}
+
+    mock_route.assert_called_once_with("/buttons/0",
+                                       ["POST", "OPTIONS"],
+                                       IgnoredArgument())
+
+
 def mock_call(uri, headers, func):
     assert uri == "buttons/0"
     assert headers == ["POST", "OPTIONS"]
@@ -57,6 +74,7 @@ def test_toggle_button_registration(mock_route):
     button.toggle("Toggle Button", do_nothing)(set_bool)
     expected = {"text": "Toggle Button",
                 "type": "button.toggle",
+                "group": None,
                 "state": False,
                 "id": 0}
 
@@ -80,3 +98,26 @@ def test_toggle_button_registration_with_invalid_args(mock_route):
         button.toggle("Toggle Button", do_nothing)(do_nothing)
     assert server.get_buttons_registered() == {'buttons': []}
     mock_route.assert_not_called()
+
+
+@patch("bottle.Bottle.route")
+def test_toggle_button_registration(mock_route):
+    server.clear_buttons()
+    button.toggle("Toggle Button", do_nothing, "Group A")(set_bool)
+    expected = {"text": "Toggle Button",
+                "type": "button.toggle",
+                "group": "Group A",
+                "state": False,
+                "id": 0}
+
+    mock_route.side_effect = mock_call
+    assert server.get_buttons_registered() == {"buttons": [expected]}
+
+    global bool_value
+    bool_value = True
+    expected["state"] = True
+    assert server.get_buttons_registered() == {"buttons": [expected]}
+
+    mock_route.assert_called_once_with("/buttons/0",
+                                       ["POST", "OPTIONS"],
+                                       IgnoredArgument())


### PR DESCRIPTION
With these changes, a user can modify the simple or toggle button and add a 'group' tag so that they can be switch between. Personally, I would find this useful so I can group buttons/actions for a specific device or room together. 

To demonstrate, I am attaching images of what the demo looks like after these changes.

Here is what it looks like when you first login. Currently, no buttons, but I'd like it to default to unassigned.
![screenshot 2018-06-16 at 5 10 53 pm](https://user-images.githubusercontent.com/9029984/41502814-5a27fcfc-7188-11e8-8b08-384f46a31d82.png)

After selecting Group A, I can view Group A buttons together, without seeing anything else.
![screenshot 2018-06-16 at 5 11 14 pm](https://user-images.githubusercontent.com/9029984/41502817-6a7817c2-7188-11e8-816c-9dfaf29307a0.png)

After selecting unassigned, I see the buttons that were not assigned to any specific group.
![screenshot 2018-06-16 at 5 11 33 pm](https://user-images.githubusercontent.com/9029984/41502829-9b16856c-7188-11e8-92e0-629001766133.png)

As someone who might want to make a lot of actions, I'd love this to be integrated. 

I'm going to comment inline for places where I wasn't sure the best way to do things and why I think a bettwer implementation could be found. I mainly wanted to get this PR out there so I could get other input.